### PR TITLE
unchunkify: per-sample MSAs

### DIFF
--- a/doc/md/unchunkify.md
+++ b/doc/md/unchunkify.md
@@ -4,6 +4,8 @@ The command reverses the effects of the [chunkify](../wiki/Subcommand:-chunkify)
 
 The easiest way to input the placement files to the command is the `--jplace-path` option, which takes a list of files or a directory containing `.jplace` files. This option works in all cases, and can even handle cases where sequences were moved around between chunks, or chunks that were merged later, and so on. It simply uses the hash names of the sequences to identify them.
 
+Optionally, when sequence file(s) containing the _chunked_ data (with hashed sequence names) are supplied to `--sequence-path`, per sample sequence files are additionally written to the output folder.
+
 ## Details
 
 For large datasets, using the `--jplace-path` option might need too much memory, as all files have to be scanned for the sequence hash names first. This is necessary if the jplace files do not correspond exactly to the chunk files. However, if each jplace file was created from one chunk file, there is no need to scan for hashes in other files. Thus, we offer two memory- and time-saving alternatives:

--- a/src/commands/prepare/unchunkify.cpp
+++ b/src/commands/prepare/unchunkify.cpp
@@ -32,6 +32,11 @@
 #include "genesis/placement/formats/jplace_writer.hpp"
 #include "genesis/placement/sample.hpp"
 
+#include "genesis/sequence/sequence.hpp"
+#include "genesis/sequence/sequence_set.hpp"
+#include "genesis/sequence/functions/labels.hpp"
+#include "genesis/sequence/formats/fasta_writer.hpp"
+
 #include "genesis/utils/containers/mru_cache.hpp"
 #include "genesis/utils/core/fs.hpp"
 #include "genesis/utils/formats/json/document.hpp"
@@ -123,6 +128,7 @@ void setup_unchunkify( CLI::App& app )
 
     opt->abundance_map_input.add_multi_file_input_opt_to_app( sub, "abundances", "json" );
     opt->jplace_input.add_jplace_input_opt_to_app( sub, false )->group( "Input" );
+    opt->sequence_input.add_sequence_input_opt_to_app( sub, false )->group( "Input" );
 
     // -----------------------------------------------------------
     //     Fill in custom options
@@ -537,6 +543,46 @@ void add_sequence_names_and_abundances(
 }
 
 /**
+ * @brief Write the actual sequences associated with this sequence hash to the output file.
+ */
+void write_all_seqs_of_hash(
+    genesis::utils::JsonDocument const&     seq_entry,
+    genesis::sequence::SequenceSet const&   msa,
+    std::ofstream&                          outstream,
+    std::string const&                      map_filename
+) {
+    using namespace genesis::sequence;
+
+    assert( outstream.is_open() );
+
+    // get the hash name and its associated sequence
+    auto const hash = seq_entry[0].get_string();
+    auto const seq_ptr = find_sequence( msa, hash );
+
+    if ( seq_ptr == nullptr ) {
+        throw std::runtime_error( "Sequence did not occur in the given query MSA: " + hash );
+    }
+
+    // if found, make a mutable copy
+    Sequence seq = *seq_ptr;
+
+    // get the actual names for this hash, add all those sequences to the output file
+    auto const& mult_arr = seq_entry[2].get_object();
+    for( auto const& mult_obj : mult_arr ) {
+        auto const& label = mult_obj.first;
+        if( ! mult_obj.second.is_number_unsigned() ) {
+            throw std::runtime_error( "Invalid abundance map: " + map_filename );
+        }
+
+        // adjust the label
+        seq.label( label );
+
+        // write out
+        FastaWriter().write_sequence( seq, outstream );
+    }
+}
+
+/**
  * @brief Main work function. Loops over all abundance map files and writes a per-sample jplace file
  * for each of them.
  */
@@ -545,9 +591,14 @@ void run_unchunkify_with_hash( UnchunkifyOptions const& options )
 {
     using namespace genesis::placement;
     using namespace genesis::utils;
+    using namespace genesis::sequence;
 
     // Get run mode
     auto const mode = get_unchunkify_mode( options );
+
+    // do we want to write per sample MSAs?
+    auto const hashed_msa = options.sequence_input.sequence_set_all();
+    bool const write_per_sample_MSAs = not hashed_msa.empty();
 
     // -----------------------------------------------------------
     //     Prepare Helper Data
@@ -621,6 +672,18 @@ void run_unchunkify_with_hash( UnchunkifyOptions const& options )
         // Create empty sample.
         Sample sample;
 
+        // Get sample name.
+        auto sample_name_it = doc.find( "sample" );
+        if( sample_name_it == doc.end() || ! sample_name_it->is_string() ) {
+            throw std::runtime_error( "Invalid abundance map: " + map_filename );
+        }
+        auto const& sample_name = sample_name_it->get_string();
+
+        // if we are to write per-sample MSAs, prepare a FastaWriter for this sample
+        std::ofstream per_sample_msa = write_per_sample_MSAs
+            ? std::ofstream(options.file_output.out_dir() + sample_name + ".fasta")
+            : std::ofstream();
+
         // Loop over mapped sequences and add them to the sample.
         for( auto seq_entry_it = abun_it->begin(); seq_entry_it != abun_it->end(); ++seq_entry_it ) {
             #pragma omp atomic
@@ -647,14 +710,11 @@ void run_unchunkify_with_hash( UnchunkifyOptions const& options )
             // Fill in the sequence, with labels and abundances.
             auto& pquery = sample.add( chunk->sample.at( pquery_idx ));
             add_sequence_names_and_abundances( *seq_entry_it, pquery, map_filename );
-        }
 
-        // Get sample name.
-        auto sample_name_it = doc.find( "sample" );
-        if( sample_name_it == doc.end() || ! sample_name_it->is_string() ) {
-            throw std::runtime_error( "Invalid abundance map: " + map_filename );
+            if ( write_per_sample_MSAs ) {
+                write_all_seqs_of_hash( *seq_entry_it, hashed_msa, per_sample_msa, map_filename );
+            }
         }
-        auto const& sample_name = sample_name_it->get_string();
 
         // We are done with the map/sample. Write it.
         jplace_writer.to_file( sample, options.file_output.out_dir() + sample_name + ".jplace" );

--- a/src/commands/prepare/unchunkify.hpp
+++ b/src/commands/prepare/unchunkify.hpp
@@ -29,6 +29,7 @@
 #include "options/jplace_input.hpp"
 #include "options/file_input.hpp"
 #include "options/file_output.hpp"
+#include "options/sequence_input.hpp"
 
 #include <string>
 #include <vector>
@@ -49,6 +50,7 @@ public:
     JplaceInputOptions jplace_input;
     FileInputOptions   abundance_map_input;
     FileOutputOptions  file_output;
+    SequenceInputOptions sequence_input;
 };
 
 // =================================================================================================


### PR DESCRIPTION
added functionality to optionally write out  per-sample MSA files, based on the chunked (hashed) query MSA