### PR TITLE
proper arithmetic operator

### DIFF
--- a/tools/deploy/check_header_guards.sh
+++ b/tools/deploy/check_header_guards.sh
@@ -70,7 +70,7 @@ for header in `find . -name "*.hpp"`; do
 
     contains_element "${guard}" "${unique_guards[@]}"
     result=$?
-    if [[ ${result} == 0 ]]; then
+    if [[ ${result} -eq 0 ]]; then
         echo "Header guard '${guard}' is not unique!"
     fi
     unique_guards+=("${guard}")


### PR DESCRIPTION
I love to read your code :-)

`==` is a string operator. It happens to work fine in this case, but I'd recommend to use the proper arithmetic operator `-eq` instead.

Also, why not?
```sh
contains_element "${guard}" "${unique_guards[@]}" && \
    echo "Header guard '${guard}' is not unique!"
```
I did not test it, but the logic seems to be the same. If the function returns zero, echo message.